### PR TITLE
Pin GitHub Actions versions using pinact

### DIFF
--- a/.github/workflows/pin-actions.yml
+++ b/.github/workflows/pin-actions.yml
@@ -17,6 +17,6 @@ jobs:
           persist-credentials: false
       
       - name: Pin actions
-        uses: suzuki-shunsuke/pinact-action@d735505f3decf76fca3fdbb4c952e5b3eba0ffdd # v0.2.2
+        uses: suzuki-shunsuke/pinact-action@49cbd6acd0dbab6a6be2585d1dbdaa43b4410133 # v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pin-actions.yml
+++ b/.github/workflows/pin-actions.yml
@@ -1,0 +1,22 @@
+name: Pin GitHub Actions
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v4.2.2
+        with:
+          persist-credentials: false
+      
+      - name: Pin actions
+        uses: suzuki-shunsuke/pinact-action@d735505f3decf76fca3fdbb4c952e5b3eba0ffdd # v0.2.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
         node-version: [20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v4.2.2
     
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,4 @@
+version: 3
+files:
+  - pattern: .github/workflows/*.yml
+  - pattern: .github/workflows/*.yaml

--- a/README.md
+++ b/README.md
@@ -218,3 +218,4 @@ Use the `full` command:
 ```sh
 npx -y llmstxt@latest full https://example.com/sitemap.xml -ep "**/privacy**" -ep "**/terms**" -rt 's/\| dotenvx//' -t 'dotenvx' > llms-full.txt
 ```
+# Additional information about pinact

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# Pin GitHub Actions versions using pinact
 # llmstxt
 
 > *generate `llms.txt` and `llms-full.txt`*–using your `sitemap.xml`. A `llms.txt` file is a curated list of your website's pages in markdown format, and `llms-full.txt` includes the full content of each page, perfect for training or fine-tuning language models with your content.


### PR DESCRIPTION
This PR addresses issue #9 by:

1. Pinning GitHub Actions versions to specific commit hashes in test.yml
2. Adding a .pinact.yaml configuration file
3. Creating a new GitHub workflow to automatically pin actions on PRs

This improves security and reliability by ensuring immutable references to GitHub Actions.